### PR TITLE
Rollup-updated version of proj4-fully-loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3695,9 +3695,9 @@
       }
     },
     "node_modules/proj4-fully-loaded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.1.0.tgz",
-      "integrity": "sha512-LfA3KHTqAAT1Nr73+atyEwiwHlWEOFWes71TwVlx1kTX0LpHWLKGGIozLY/sIgthoqq6Pf5n58RukdDyMKdRBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.2.0.tgz",
+      "integrity": "sha512-9rlkLe9+l8iFpviYiQjdHbw9d3iOmUAF1UlbaVkofvbI26/0/EOWtYku9ln+dJuAovrqHyoJ984G5/edQxvHng==",
       "dependencies": {
         "proj4": "^2.8.0",
         "proj4js-definitions": "^0.1.0"
@@ -3910,15 +3910,6 @@
       "integrity": "sha512-X72F4Ry/KXjuhf43KrTX8KoJtg7C4YaQ3m0nJLyR2wCAFIjaR4zzufbu/m7T+19D/iVf6BS/ReOaDG0LtC8wCw==",
       "dependencies": {
         "proj4-fully-loaded": "^0.0.4"
-      }
-    },
-    "node_modules/reproject-geojson/node_modules/proj4-fully-loaded": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.0.4.tgz",
-      "integrity": "sha512-74v+nA/T6Hcilukd0nFNTNSEf6Up62jzpLssk4Pr6psRWy2nZCdFV90kb4ZjmbbqBqu7V4D8G9C5V54NixBK4g==",
-      "dependencies": {
-        "proj4": "^2.7.2",
-        "proj4js-definitions": "^0.1.0"
       }
     },
     "node_modules/resolve": {
@@ -7358,7 +7349,7 @@
         "geo-extent": "^0.11.0",
         "geocanvas": "^0.3.1",
         "pixel-utils": "^0.7.0",
-        "proj4-fully-loaded": "^0.1.0",
+        "proj4-fully-loaded": "^0.2.0",
         "regenerator-runtime": "^0.13.9",
         "reproject-bbox": "^0.4.1",
         "snap-bbox": "^0.2.0",
@@ -8487,9 +8478,9 @@
       }
     },
     "proj4-fully-loaded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.1.0.tgz",
-      "integrity": "sha512-LfA3KHTqAAT1Nr73+atyEwiwHlWEOFWes71TwVlx1kTX0LpHWLKGGIozLY/sIgthoqq6Pf5n58RukdDyMKdRBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.2.0.tgz",
+      "integrity": "sha512-9rlkLe9+l8iFpviYiQjdHbw9d3iOmUAF1UlbaVkofvbI26/0/EOWtYku9ln+dJuAovrqHyoJ984G5/edQxvHng==",
       "requires": {
         "proj4": "^2.8.0",
         "proj4js-definitions": "^0.1.0"
@@ -8674,7 +8665,7 @@
       "resolved": "https://registry.npmjs.org/reproject-bbox/-/reproject-bbox-0.4.2.tgz",
       "integrity": "sha512-lu8nTA/IJORIQdB0AqOV6TjIkNwn4Y3QIZ8DU+lY/Z1TZrD6eMyLTGoX6+WKIc1e4xccb7KoyrUYVPe7mmiVsA==",
       "requires": {
-        "proj4-fully-loaded": "^0.1.0",
+        "proj4-fully-loaded": "^0.2.0",
         "proj4-merge": "^0.1.1"
       }
     },
@@ -8683,18 +8674,7 @@
       "resolved": "https://registry.npmjs.org/reproject-geojson/-/reproject-geojson-0.1.2.tgz",
       "integrity": "sha512-X72F4Ry/KXjuhf43KrTX8KoJtg7C4YaQ3m0nJLyR2wCAFIjaR4zzufbu/m7T+19D/iVf6BS/ReOaDG0LtC8wCw==",
       "requires": {
-        "proj4-fully-loaded": "^0.0.4"
-      },
-      "dependencies": {
-        "proj4-fully-loaded": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/proj4-fully-loaded/-/proj4-fully-loaded-0.0.4.tgz",
-          "integrity": "sha512-74v+nA/T6Hcilukd0nFNTNSEf6Up62jzpLssk4Pr6psRWy2nZCdFV90kb4ZjmbbqBqu7V4D8G9C5V54NixBK4g==",
-          "requires": {
-            "proj4": "^2.7.2",
-            "proj4js-definitions": "^0.1.0"
-          }
-        }
+        "proj4-fully-loaded": "^0.2.0"
       }
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -13,5 +13,20 @@
   },
   "dependencies": {
     "georaster-layer-for-leaflet": "^3.10.0"
+  },
+  "overrides": {
+    "georaster-layer-for-leaflet": {
+      "proj4-fully-loaded": "^0.2.0",
+      "reproject-bbox": {
+        "proj4-fully-loaded": "^0.2.0"
+      },
+      "geocanvas": {
+        "geomask": {
+          "reproject-geojson": {
+            "proj4-fully-loaded": "^0.2.0"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Here `proj4-fully-loaded` in the dependency tree is set to point to the version that has been updated with Rollup support.